### PR TITLE
Update actions.yaml to send build status to Teams via webhook

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -28,3 +28,19 @@ jobs:
       - name: Install dependencies
         working-directory: ${{ matrix.service }}
         run: npm install
+        
+      - name: Notify Teams
+        if: always()
+        env:
+          STATUS: ${{ job.status }}
+        run: |
+          curl -H "Content-Type: application/json" \
+               -d "{
+                    \"@type\": \"MessageCard\",
+                    \"@context\": \"http://schema.org/extensions\",
+                    \"summary\": \"Build Notification\",
+                    \"themeColor\": \"0076D7\",
+                    \"title\": \"CI Build Result\",
+                    \"text\": \"Service: **${{ matrix.service }}**<br>Status: **${STATUS}**\"
+                  }" \
+               ${{ secrets.TEAMS_WEBHOOK_URL }}


### PR DESCRIPTION
This configuration uses a GitHub actions webhook to notify the builds in Teams.
<img width="1092" height="561" alt="image-31" src="https://github.com/user-attachments/assets/945bf963-8ef1-4378-950d-42ded45757ec" />
